### PR TITLE
fix: correct 'inf' handling with numba

### DIFF
--- a/src/umato/umato_.py
+++ b/src/umato/umato_.py
@@ -66,7 +66,7 @@ INT32_MAX = np.iinfo(np.int32).max - 1
 
 @numba.njit(
     # parallel=True,  # can SABOTAGE the array order (should be used with care)
-    fastmath=True,
+    fastmath={'nnan', 'nsz', 'arcp', 'contract', 'afn', 'reassoc'},
 )
 def build_knn_graph(
     data, sorted_index, hub_num,


### PR DESCRIPTION
Enabling all numba fastmath options results in the 'ninf' flag being triggered, leading to unexpected behavior in the build_knn_graph function.

This fix explicitly specifies which fastmath flags to enable(excluding, of course, 'ninf'), so that the function works as expected.

Fixes #11 .