### PR TITLE
Remove nested numba.prange

### DIFF
--- a/src/umato/umato_.py
+++ b/src/umato/umato_.py
@@ -452,7 +452,7 @@ def select_from_knn(
 
     for i in numba.prange(knn_indices.shape[0]):
         if hub_info[i] > 0:
-            for j in numba.prange(knn_indices.shape[1]):
+            for j in range(knn_indices.shape[1]):
                 # append directly if it is not an outlier
                 if hub_info[knn_indices[i, j]] > 0:
                     out_indices[i, counts[i]] = knn_indices[i, j]

--- a/src/umato/umato_pva.py
+++ b/src/umato/umato_pva.py
@@ -400,7 +400,7 @@ def select_from_knn(
 
     for i in numba.prange(knn_indices.shape[0]):
         if hub_info[i] > 0:
-            for j in numba.prange(knn_indices.shape[1]):
+            for j in range(knn_indices.shape[1]):
                 # append directly if it is not an outlier
                 if hub_info[knn_indices[i, j]] > 0:
                     out_indices[i, counts[i]] = knn_indices[i, j]


### PR DESCRIPTION
This resolves the following warning by using a standard range for the inner loop.

```
: NumbaPerformanceWarning: 
prange or pndindex loop will not be executed in parallel due to there being more than one entry to or exit from the loop (e.g., an assertion).

File "../src/umato/umato_.py", line 455:
def select_from_knn(
    <source elided>
        if hub_info[i] > 0:
            for j in numba.prange(knn_indices.shape[1]):
            ^

  warnings.warn(
```