### PR TITLE
precomputed is a valid metric string

### DIFF
--- a/src/umato/umato_.py
+++ b/src/umato/umato_.py
@@ -715,7 +715,9 @@ class UMATO(BaseEstimator):
                     )
             else:
                 self._input_distance_func = dist.named_distances[self.metric]
-        else:
+	elif self.metric == 'precomputed':
+		pass
+	else:
             raise ValueError("metric is not a recognised string")
 
         # set angularity for NN search based on metric

--- a/src/umato/umato_.py
+++ b/src/umato/umato_.py
@@ -716,7 +716,7 @@ class UMATO(BaseEstimator):
             else:
                 self._input_distance_func = dist.named_distances[self.metric]
 	elif self.metric == 'precomputed':
-		pass
+		self._input_distance_func = 'precomputed'
 	else:
             raise ValueError("metric is not a recognised string")
 


### PR DESCRIPTION
please consider this minor bug fix where 'precomputed' wasn't listed in the allowed `metric` parameters